### PR TITLE
Fix: Update triangulation figures

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: idmc
 Title: Load and Wrangle IDMC Displacement Data
-Version: 0.3.1
+Version: 0.4.0
 Authors@R: 
     person(
-      given = "Seth",
-      family = "Caldwell", 
-      email = "caldwellst@gmail.com",
+      given = "Giulia",
+      family = "Martini", 
+      email = "giulia.martini@un.org",
       role = c("aut", "cre", "cph")
     )
 Description: Utilities to work with data from the Internal Displacement

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ URL: https://github.com/ocha-dap/idmc
 BugReports: https://github.com/ocha-dap/idmc/issues
 Imports: 
     dplyr,
+    glue,
     httr,
     jsonlite,
     lifecycle,

--- a/R/idmc_transform_daily.R
+++ b/R/idmc_transform_daily.R
@@ -83,12 +83,12 @@ idmc_transform_daily <- function(
   df_triangulation_figures_same_location <- df %>%
     dplyr::filter((role == "Triangulation")& !(event_id %in% df_recommended_figures$event_id )) %>%
     dplyr::mutate(created_at = as.POSIXct(created_at)) %>%
-    dplyr::group_by(event_id, locations_coordinates) %>%
+    dplyr::group_by(event_id, locations_coordinates, displacement_date) %>%
     dplyr::slice_max(order_by = created_at, n = 1, with_ties = FALSE)
 
   # if no recommended figure, and multiple locations for an event_id,
-  # sum figures and take latest created_at to have a single entry per event_id
-  df_triangulation_figures_different_location <- df_triangulation_figures_same_location %>% dplyr::group_by(.data$event_id) |>
+  # sum figures and take latest created_at to have a single entry per event_id, displacement_date
+  df_triangulation_figures_different_location <- df_triangulation_figures_same_location %>% dplyr::group_by(.data$event_id, .data$displacement_date) |>
     dplyr::mutate(figure=sum(figure), na.rm = TRUE) %>%
     dplyr::slice_max(order_by = created_at, n = 1, with_ties = FALSE)
 

--- a/R/idmc_transform_daily.R
+++ b/R/idmc_transform_daily.R
@@ -83,7 +83,7 @@ idmc_transform_daily <- function(
   # if no recommended figure, take latest triangulation figure for each event_id and location
   df_triangulation_figures_same_location <- df %>%
     dplyr::filter((.data$role == "Triangulation")& !(.data$event_id %in% df_recommended_figures$event_id )) %>%
-    dplyr::mutate(.data$created_at = as.POSIXct(.data$created_at)) %>%
+    dplyr::mutate(created_at = as.POSIXct(.data$created_at)) %>%
     dplyr::group_by(.data$event_id, .data$locations_coordinates) %>%
     dplyr::slice_max(order_by = .data$created_at, n = 1, with_ties = FALSE)
 

--- a/R/idmc_transform_daily.R
+++ b/R/idmc_transform_daily.R
@@ -82,10 +82,10 @@ idmc_transform_daily <- function(
 
   # if no recommended figure, take latest triangulation figure for each event_id and location
   df_triangulation_figures_same_location <- df %>%
-    dplyr::filter((role == "Triangulation")& !(event_id %in% df_recommended_figures$event_id )) %>%
-    dplyr::mutate(created_at = as.POSIXct(created_at)) %>%
-    dplyr::group_by(event_id, locations_coordinates) %>%
-    dplyr::slice_max(order_by = created_at, n = 1, with_ties = FALSE)
+    dplyr::filter((.data$role == "Triangulation")& !(.data$event_id %in% df_recommended_figures$event_id )) %>%
+    dplyr::mutate(.data$created_at = as.POSIXct(.data$created_at)) %>%
+    dplyr::group_by(.data$event_id, .data$locations_coordinates) %>%
+    dplyr::slice_max(order_by = .data$created_at, n = 1, with_ties = FALSE)
 
   # if no recommended figure, and multiple locations for an event_id,
   # sum figures and take:
@@ -104,12 +104,12 @@ idmc_transform_daily <- function(
 
   df_daily <- df_combined %>% dplyr::rowwise() %>%
     dplyr::mutate(
-      date = if (!is.na(displacement_start_date) && !is.na(displacement_end_date)) {
-        list(seq(displacement_start_date, displacement_end_date, by = "day"))
+      date = if (!is.na(.data$displacement_start_date) && !is.na(.data$displacement_end_date)) {
+        list(seq(.data$displacement_start_date, .data$displacement_end_date, by = "day"))
       } else {
         list(as.Date(character()))  # empty sequence instead of NA
       },
-      displacement_daily = if (!is.na(displacement_start_date) && !is.na(displacement_end_date)) {
+      displacement_daily = if (!is.na(.data$displacement_start_date) && !is.na(.data$displacement_end_date)) {
         figure / length(date)
       } else {
         NA_real_
@@ -128,7 +128,7 @@ idmc_transform_daily <- function(
     )
 
   n_missing_dates <- df_combined %>%
-    dplyr::filter(is.na(displacement_start_date) | is.na(displacement_end_date)) %>%
+    dplyr::filter(is.na(.data$displacement_start_date) | is.na(.data$displacement_end_date)) %>%
     nrow()
   if (n_missing_dates > 0) {
     warning(glue::glue("{n_missing_dates} rows dropped because of missing start or end dates."))

--- a/R/idmc_transform_daily.R
+++ b/R/idmc_transform_daily.R
@@ -83,18 +83,16 @@ idmc_transform_daily <- function(
   df_triangulation_figures_same_location <- df %>%
     dplyr::filter((role == "Triangulation")& !(event_id %in% df_recommended_figures$event_id )) %>%
     dplyr::mutate(created_at = as.POSIXct(created_at)) %>%
-    dplyr::group_by(event_id, locations_coordinates, displacement_date) %>%
+    dplyr::group_by(event_id, locations_coordinates) %>%
     dplyr::slice_max(order_by = created_at, n = 1, with_ties = FALSE)
 
   # if no recommended figure, and multiple locations for an event_id,
   # sum figures and take latest created_at to have a single entry per event_id
   df_triangulation_figures_different_location <- df_triangulation_figures_same_location %>%
-    dplyr::group_by(.data$event_id) %>%
-    dplyr::summarize(
-      figure = sum(.data$figure, na.rm = TRUE),
-      created_at = max(.data$created_at, na.rm = TRUE),
-      .groups = "drop"
-    )
+    dplyr::group_by(.data$event_id)  %>%
+    dplyr::mutate(figure = sum(.data$figure, na.rm = TRUE)) %>%  # sum within event_id
+    dplyr::slice_max(.data$created_at, n = 1, with_ties = FALSE) %>% # keep latest row
+    dplyr::ungroup()
 
   df_combined <- dplyr::bind_rows(
     df_recommended_figures,

--- a/R/idmc_transform_daily.R
+++ b/R/idmc_transform_daily.R
@@ -87,20 +87,31 @@ idmc_transform_daily <- function(
     dplyr::slice_max(order_by = created_at, n = 1, with_ties = FALSE)
 
   # if no recommended figure, and multiple locations for an event_id,
-  # sum figures and take latest created_at to have a single entry per event_id, displacement_date
-  df_triangulation_figures_different_location <- df_triangulation_figures_same_location %>% dplyr::group_by(.data$event_id, .data$displacement_date) |>
-    dplyr::mutate(figure=sum(figure), na.rm = TRUE) %>%
-    dplyr::slice_max(order_by = created_at, n = 1, with_ties = FALSE)
+  # sum figures and take latest created_at to have a single entry per event_id
+  df_triangulation_figures_different_location <- df_triangulation_figures_same_location %>%
+    dplyr::group_by(.data$event_id) %>%
+    dplyr::summarize(
+      figure = sum(.data$figure, na.rm = TRUE),
+      created_at = max(.data$created_at, na.rm = TRUE),
+      .groups = "drop"
+    )
 
-  df_daily <- dplyr::bind_rows(
+  df_combined <- dplyr::bind_rows(
     df_recommended_figures,
-    df_triangulation_figures_different_location
-  ) %>% dplyr::rowwise() %>%
+    df_triangulation_figures_different_location)
+
+  df_daily <- df_combined %>% dplyr::rowwise() %>%
     dplyr::mutate(
-      date = list(
-        seq(.data$displacement_start_date, .data$displacement_end_date, by = "day")
-      ),
-      displacement_daily = .data$figure / length(.data$date)
+      date = if (!is.na(displacement_start_date) && !is.na(displacement_end_date)) {
+        list(seq(displacement_start_date, displacement_end_date, by = "day"))
+      } else {
+        list(as.Date(character()))  # empty sequence instead of NA
+      },
+      displacement_daily = if (!is.na(displacement_start_date) && !is.na(displacement_end_date)) {
+        figure / length(date)
+      } else {
+        NA_real_
+      }
     ) %>%
     dplyr::ungroup() %>%
     tidyr::unnest(
@@ -114,6 +125,12 @@ idmc_transform_daily <- function(
       .groups = "drop"
     )
 
+  n_missing_dates <- df_combined %>%
+    dplyr::filter(is.na(displacement_start_date) | is.na(displacement_end_date)) %>%
+    nrow()
+  if (n_missing_dates > 0) {
+    warning(glue::glue("{n_missing_dates} rows dropped because of missing start or end dates."))
+  }
   # replace with NA so that no backfilling or extrapolation occurs
 
   if (is.null(max_date)) {


### PR DESCRIPTION
Update computation of triangulation figures according to the [IDMC documentation](https://www.internal-displacement.org/database/api-documentation/):
"Triangulation figures with different locations: For an event, in the absence of recommended figures and the presence of multiple triangulation figures sharing the same flow dates but referring to different locations, these figures are to be combined. This method enables the representation of the total number of internal displacements arising from an event across various locations. "

**Fix:**
- When recommended figure is available, that one is taken (as in the previous version)
- When it's not available, the latest figure for each `event_id` and `locations_coordinates` is taken. 
      - then the figures are sum together for each `event_id`
      - the `displacement_start_date` is fixed as the minimum across the different `locations_coordinates` for         each `event_id` 
      - the `displacement_end_date` is fixed as the maximum across the different `locations_coordinates` for         each `event_id`
      
   **NOTE**: the last two points have the effect that the daily values in the `data_daily` dataframe can be lower than in the current version as the figure value might be spread for a longer number of days, resulting in lower daily average.
